### PR TITLE
[WIP] Instead of shelling out, use the bundler audit API

### DIFF
--- a/lib/bundler/organization_audit.rb
+++ b/lib/bundler/organization_audit.rb
@@ -55,7 +55,7 @@ module Bundler
       def vulnerable?(file)
         Bundler::LockfileParser.new(file).specs.each do |gem|
           @database.check_gem(gem) do |advisory|
-            return true
+            return true unless @ignore.include?(advisory.id)
           end
         end
 

--- a/lib/bundler/organization_audit.rb
+++ b/lib/bundler/organization_audit.rb
@@ -7,8 +7,7 @@ module Bundler
   module OrganizationAudit
     class << self
       def run(options)
-        @database = Bundler::Audit::Database.new
-        @ignore = options[:ignore_advisories] || []
+        @ignore = options[:ignore_advisories]
         vulnerable = find_vulnerable(options)
         if vulnerable.size == 0
           0
@@ -56,8 +55,8 @@ module Bundler
       def vulnerable?(file)
         vulnerable = false
         Bundler::LockfileParser.new(file).specs.each do |gem|
-          @database.check_gem(gem) do |advisory|
-            next if @ignore.include?(advisory.id)
+          database.check_gem(gem) do |advisory|
+            next if ignore.include?(advisory.id)
             next unless advisory.vulnerable?(gem.version)
 
             print_advisory(gem, advisory)
@@ -65,6 +64,14 @@ module Bundler
           end
         end
         vulnerable
+      end
+
+      def ignore
+        @ignore || []
+      end
+
+      def database
+        @database ||= Bundler::Audit::Database.new
       end
 
       def print_advisory(gem, advisory)

--- a/spec/bundler/organization_audit_spec.rb
+++ b/spec/bundler/organization_audit_spec.rb
@@ -17,7 +17,7 @@ describe Bundler::OrganizationAudit do
         out = record_out do
           Bundler::OrganizationAudit.send(:audit_repo, repo, {})
         end
-        out.strip.should == "parallel\nbundle-audit\nNo unpatched versions found"
+        out.should =~ %r{Solution: upgrade to >= 4.2.2, ~> 4.1.11}
       end
     end
 


### PR DESCRIPTION
Before I learned that this gem existed, I had written a basic script that accomplishes almost the same thing. However, I used the bundler audit API instead of shelling out. I'm generally a fan of APIs over CLIs but I can also understand the argument for shelling out. I'm just assuming this is faster as well.

I think this approach simplifies things a bit. wdyt @grosser?

Not implemented: ignore functionality

In my very, very limited testing the results were the same.